### PR TITLE
Link shader compile dependencies privately

### DIFF
--- a/lvk/vulkan/CMakeLists.txt
+++ b/lvk/vulkan/CMakeLists.txt
@@ -39,7 +39,7 @@ lvk_set_folder(glslang-default-resource-limits "third-party/glslang")
 find_package(Vulkan REQUIRED)
 
 target_link_libraries(LVKVulkan PRIVATE LVKLibrary)
-target_link_libraries(LVKVulkan PUBLIC glslang SPIRV glslang-default-resource-limits)
+target_link_libraries(LVKVulkan PRIVATE glslang SPIRV glslang-default-resource-limits)
 target_link_libraries(LVKVulkan PUBLIC Vulkan::Vulkan)
 
 target_include_directories(LVKVulkan PUBLIC "${LVK_ROOT_DIR}/third-party/deps/src/volk")

--- a/lvk/vulkan/VulkanUtils.cpp
+++ b/lvk/vulkan/VulkanUtils.cpp
@@ -10,6 +10,8 @@
 #include <igl/vulkan/Common.h>
 #include <igl/vulkan/VulkanContext.h>
 
+#include <glslang/Include/glslang_c_interface.h>
+
 VkSemaphore lvk::createSemaphore(VkDevice device, const char* debugName) {
   const VkSemaphoreCreateInfo ci = {
       .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,

--- a/lvk/vulkan/VulkanUtils.h
+++ b/lvk/vulkan/VulkanUtils.h
@@ -17,8 +17,9 @@
 
 #include <volk.h>
 #include <vk_mem_alloc.h>
-#include <glslang/Include/glslang_c_interface.h>
 #include <lvk/LVK.h>
+
+typedef struct glslang_resource_s glslang_resource_t;
 
 namespace lvk {
 

--- a/src/igl/vulkan/CMakeLists.txt
+++ b/src/igl/vulkan/CMakeLists.txt
@@ -18,7 +18,7 @@ igl_set_folder(IGLVulkan "IGL")
 
 target_link_libraries(IGLVulkan PRIVATE LVKLibrary)
 target_link_libraries(IGLVulkan PRIVATE LVKVulkan)
-target_link_libraries(IGLVulkan PUBLIC glslang SPIRV glslang-default-resource-limits)
+target_link_libraries(IGLVulkan PRIVATE glslang SPIRV glslang-default-resource-limits)
 target_link_libraries(IGLVulkan PUBLIC Vulkan::Vulkan)
 
 target_include_directories(IGLVulkan PUBLIC "${LVK_ROOT_DIR}/third-party/deps/src/volk")

--- a/src/igl/vulkan/Device.cpp
+++ b/src/igl/vulkan/Device.cpp
@@ -19,6 +19,8 @@
 #include <igl/vulkan/VulkanSwapchain.h>
 #include <igl/vulkan/VulkanTexture.h>
 
+#include <glslang/Include/glslang_c_interface.h>
+
 namespace {
 
 bool supportsFormat(VkPhysicalDevice physicalDevice, VkFormat format) {

--- a/src/igl/vulkan/VulkanContext.cpp
+++ b/src/igl/vulkan/VulkanContext.cpp
@@ -20,6 +20,8 @@
 #include <igl/vulkan/VulkanTexture.h>
 #include <lvk/vulkan/VulkanUtils.h>
 
+#include <glslang/Include/glslang_c_interface.h>
+
 static_assert(lvk::HWDeviceDesc::IGL_MAX_PHYSICAL_DEVICE_NAME_SIZE <= VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
 
 namespace {

--- a/src/igl/vulkan/VulkanHelpers.h
+++ b/src/igl/vulkan/VulkanHelpers.h
@@ -9,12 +9,11 @@
 
 #pragma once
 
-#include <glslang/Include/glslang_c_interface.h>
-
 #if !defined(VK_NO_PROTOTYPES)
 #define VK_NO_PROTOTYPES
 #endif // !defined(VK_NO_PROTOTYPES)
 
+#include <stdbool.h>
 #include <volk.h>
 
 #ifdef __cplusplus

--- a/src/igl/vulkan/VulkanShaderModule.h
+++ b/src/igl/vulkan/VulkanShaderModule.h
@@ -12,6 +12,8 @@
 #include <igl/vulkan/Common.h>
 #include <igl/vulkan/VulkanHelpers.h>
 
+typedef struct glslang_resource_s glslang_resource_t;
+
 namespace lvk {
 namespace vulkan {
 


### PR DESCRIPTION
Link times are very long, shader compilation is a heavy dependency, hopefully this helps a bit.

Targeting just Vulkan, offline compilation with a tool like [ShaderMake](https://github.com/NVIDIAGameWorks/ShaderMake) may be preferable. It supports shader combinations with a custom binary format. First-class support for it in this library would be a nice feature.

Additionally, I can't make issues on a fork, so I'll put it here: 840mb of dependencies are downloaded when not building samples. Unfortunate as this abstraction is otherwise very lightweight. I'm not familiar with this python buildscript, but preferably core dependencies (i.e. minilog) would be downloaded & managed by CMake `FetchContent`? They could then be lazily acquired with `FindPackage`.