### PR TITLE
Fix aggregate initialization compile error

### DIFF
--- a/samples/Tiny_MeshLarge.cpp
+++ b/samples/Tiny_MeshLarge.cpp
@@ -651,6 +651,7 @@ void initIGL() {
                  .clearColor = {0.0f, 0.0f, 0.0f, 1.0f}}},
   };
   renderPassShadow_ = {
+      .color = {},
       .depth = {.loadOp = lvk::LoadOp_Clear, .storeOp = lvk::StoreOp_Store, .clearDepth = 1.0f},
   };
 }


### PR DESCRIPTION
this part of the code is not compiled with gcc 13.

in c++ 17 standard, according to the [cppreference](https://en.cppreference.com/w/cpp/language/aggregate_initialization):

> if the initializer list is non-empty, the explicitly initialized elements of the aggregate are the first n elements of the aggregate, where n is the number of elements in the initializer list.
> Otherwise, the initializer list must be empty ({}), and there are no explicitly initialized elements.

also, using the designated initializer is not allowed under the c++20, some compilers might not support it, I'm not sure if you did it on purpose. 