### PR TITLE
Fix VK_SUBOPTIMAL_KHR processing

### DIFF
--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -185,6 +185,7 @@ class VulkanSwapchain final {
   VkImage getCurrentVkImage() const;
   VkImageView getCurrentVkImageView() const;
   TextureHandle getCurrentTexture();
+  const VkSurfaceFormatKHR& getSurfaceFormat() const;
 
  public:
   VkSemaphore acquireSemaphore_ = VK_NULL_HANDLE;


### PR DESCRIPTION
Fixed not stable bug.

The pipelines in the samples (and possibly other apps) are created immediately after glfw window. The window can't appear on the screen yet.
```
  renderPipelineState_Mesh_ = ctx_->createRenderPipeline(
      {
          .smVert = vert_,
          .smFrag = frag_,
          .color =
              {
                  {.format = ctx_->getSwapchainFormat()},
              },
```
This code leads to `getCurrentTexture` call from the swapchain.
```
lvk::Format lvk::VulkanContext::getSwapchainFormat() const {
  if (!hasSwapchain()) {
    return Format_Invalid;
  }

  return getFormat(swapchain_->getCurrentTexture());
}
```
This leads to
```
  if (getNextImage_) {
    // when timeout is set to UINT64_MAX, we wait until the next image has been acquired
    VK_ASSERT(vkAcquireNextImageKHR(device_, swapchain_, UINT64_MAX, acquireSemaphore_, VK_NULL_HANDLE, &currentImageIndex_));
    getNextImage_ = false;
  }
```
`vkAcquireNextImageKHR` returns `VK_SUBOPTIMAL_KHR`, and an app crashes.

VK_SUBOPTIMAL_KHR is valid code in some sense.
> VK_SUBOPTIMAL_KHR - Presentation will still succeed, subject to the window resize behavior, but the swapchain is no longer configured optimally for the surface it targets. Applications should query updated surface information and recreate their swapchain at the next convenient opportunity.

See: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_swapchain.html

This PR adds processing of VK_SUBOPTIMAL_KHR.
