### PR TITLE
Fix texture bugs

### DIFF
--- a/lvk/LVK.cpp
+++ b/lvk/LVK.cpp
@@ -74,6 +74,7 @@ static constexpr TextureFormatProperties properties[] = {
     PROPS(Z_UN24, 3, .depth = true),
     PROPS(Z_F32, 4, .depth = true),
     PROPS(Z_UN24_S_UI8, 4, .depth = true, .stencil = true),
+    PROPS(Z_F32_S_UI8, 5, .depth = true, .stencil = true),
 };
 
 } // namespace
@@ -83,7 +84,7 @@ void* createCocoaWindowView(GLFWwindow* window);
 #endif
 
 static_assert(sizeof(TextureFormatProperties) <= sizeof(uint32_t));
-static_assert(LVK_ARRAY_NUM_ELEMENTS(properties) == lvk::Format_Z_UN24_S_UI8 + 1);
+static_assert(LVK_ARRAY_NUM_ELEMENTS(properties) == lvk::Format_Z_F32_S_UI8 + 1);
 
 bool lvk::isDepthOrStencilFormat(lvk::Format format) {
   return properties[format].depth || properties[format].stencil;

--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * LightweightVK
  *
  * This source code is licensed under the MIT license found in the
@@ -471,6 +471,7 @@ enum Format : uint8_t {
   Format_Z_UN24,
   Format_Z_F32,
   Format_Z_UN24_S_UI8,
+  Format_Z_F32_S_UI8,
 };
 
 enum LoadOp : uint8_t {

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -4592,7 +4592,7 @@ void lvk::VulkanContext::checkAndUpdateDescriptorSets() {
   for (const auto& obj : texturesPool_.objects_) {
     const VulkanTexture& texture = obj.obj_;
     // multisampled images cannot be directly accessed from shaders
-    const bool isTextureAvailable = (texture.image_->vkSamples_ & VK_SAMPLE_COUNT_1_BIT) == VK_SAMPLE_COUNT_1_BIT;
+    const bool isTextureAvailable = texture.image_ && ((texture.image_->vkSamples_ & VK_SAMPLE_COUNT_1_BIT) == VK_SAMPLE_COUNT_1_BIT);
     const bool isSampledImage = isTextureAvailable && texture.image_->isSampledImage();
     const bool isStorageImage = isTextureAvailable && texture.image_->isStorageImage();
     infoSampledImages.push_back(

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -418,6 +418,8 @@ std::vector<VkFormat> getCompatibleDepthStencilFormats(lvk::Format format) {
     return {VK_FORMAT_D32_SFLOAT, VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT};
   case lvk::Format_Z_UN24_S_UI8:
     return {VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D16_UNORM_S8_UINT};
+  case lvk::Format_Z_F32_S_UI8:
+    return {VK_FORMAT_D32_SFLOAT_S8_UINT, VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D16_UNORM_S8_UINT};
   default:
     return {VK_FORMAT_D24_UNORM_S8_UINT, VK_FORMAT_D32_SFLOAT};
   }

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -4039,6 +4039,7 @@ lvk::Result lvk::VulkanContext::initContext(const HWDeviceDesc& desc) {
       .drawIndirectFirstInstance = VK_TRUE,
       .depthBiasClamp = VK_TRUE,
       .fillModeNonSolid = VK_TRUE,
+      .samplerAnisotropy = VK_TRUE,
       .textureCompressionBC = VK_TRUE,
   };
   VkPhysicalDeviceVulkan11Features deviceFeatures11 = {

--- a/lvk/vulkan/VulkanUtils.cpp
+++ b/lvk/vulkan/VulkanUtils.cpp
@@ -176,6 +176,8 @@ VkFormat lvk::formatToVkFormat(lvk::Format format) {
     return VK_FORMAT_D32_SFLOAT;
   case lvk::Format_Z_UN24_S_UI8:
     return VK_FORMAT_D24_UNORM_S8_UINT;
+  case lvk::Format_Z_F32_S_UI8:
+    return VK_FORMAT_D32_SFLOAT_S8_UINT;
   }
 #if defined(_MSC_VER)
   LVK_ASSERT_MSG(false, "TextureFormat value not handled: %d", (int)format);
@@ -235,6 +237,8 @@ lvk::Format lvk::vkFormatToFormat(VkFormat format) {
     return Format_Z_UN24_S_UI8;
   case VK_FORMAT_D32_SFLOAT:
     return Format_Z_F32;
+  case VK_FORMAT_D32_SFLOAT_S8_UINT:
+    return Format_Z_F32_S_UI8;
   default:;
   }
   LVK_ASSERT_MSG(false, "VkFormat value not handled: %d", (int)format);


### PR DESCRIPTION
Fixed bugs:
1. [Fix missing samplerAnisotropy feature](https://github.com/corporateshark/lightweightvk/commit/f7aa2040e8ff1faed83f9a456433973a957e3291)
```
ERROR:
Validation layer:
vkCreateSampler(): Anisotropic sampling feature is not enabled, pCreateInfo->anisotropyEnable must be VK_FALSE. The Vulkan spec states: If the samplerAnisotropy feature is not enabled, anisotropyEnable must be VK_FALSE (https://vulkan.lunarg.com/doc/view/1.3.261.1/mac/1.3-extensions/vkspec.html#VUID-VkSamplerCreateInfo-anisotropyEnable-01070)
```
2. [Fix D24U_S8 -> D32F_S8 promotion in MoltenVK](https://github.com/corporateshark/lightweightvk/commit/bf988e5bdb27749ed147a2904875c108301f1022)
In Metal doesn't support D24U_S8, so MoltenVK doesn't as well.  D24U_S8 is promoted to D32F_S8 by LVK, but back conversion from VK_FORMAT_D32_SFLOAT_S8_UINT wasn't implemented. 

3. [Fix nullptr access in checkAndUpdateDescriptorSets](https://github.com/corporateshark/lightweightvk/pull/10/commits/64ff49262606964651062ffd1540df50dffb1f97)]
`texture.image_` can be `nullptr`.