### PR TITLE
Add LVK_WITH_GLFW parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,24 @@ cmake_minimum_required(VERSION 3.16)
 project("LVK" CXX C)
 
 # cmake-format: off
-option(LVK_WITH_SAMPLES "Enable sample demo apps"  ON)
-option(LVK_WITH_TRACY   "Enable Tracy profiler"    ON)
 option(LVK_DEPLOY_DEPS  "Deploy dependencies via CMake" ON)
+option(LVK_WITH_GLFW    "Enable GLFW"                   ON)
+option(LVK_WITH_SAMPLES "Enable sample demo apps"       ON)
+option(LVK_WITH_TRACY   "Enable Tracy profiler"         ON)
 # cmake-format: on
+
+if(LVK_WITH_SAMPLES AND NOT LVK_WITH_GLFW)
+  message(STATUS "WARNING: LVK_WITH_SAMPLES=ON leads to forcing LVK_WITH_GLFW=ON")
+  set(LVK_WITH_GLFW ON)
+endif()
+if (ANDROID)
+  message(STATUS "WARNING: LVK_WITH_GLFW and LVK_WITH_SAMPLES were set to OFF for Android")
+  set(LVK_WITH_GLFW OFF)
+  set(LVK_WITH_SAMPLES OFF)
+endif()
+if(LVK_WITH_GLFW)
+  add_definitions(-DLVK_WITH_GLFW=1)
+endif()
 
 include(cmake/CommonMacros.txt)
 
@@ -34,9 +48,10 @@ endfunction()
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # cmake-format: off
+message(STATUS "LVK_DEPLOY_DEPS  = ${LVK_DEPLOY_DEPS}")
+message(STATUS "LVK_WITH_GLFW    = ${LVK_WITH_GLFW}")
 message(STATUS "LVK_WITH_SAMPLES = ${LVK_WITH_SAMPLES}")
 message(STATUS "LVK_WITH_TRACY   = ${LVK_WITH_TRACY}")
-message(STATUS "LVK_DEPLOY_DEPS  = ${LVK_DEPLOY_DEPS}")
 # cmake-format: on
 
 if(NOT DEFINED CMAKE_BUILD_TYPE)
@@ -108,7 +123,7 @@ lvk_set_folder(minilog "third-party")
 target_link_libraries(LVKLibrary PUBLIC minilog)
 target_include_directories(LVKLibrary PUBLIC "third-party/deps/src")
 
-if(WIN32 OR (UNIX AND NOT ANDROID))
+if(LVK_WITH_GLFW)
   # cmake-format: off
   set(GLFW_BUILD_DOCS     OFF CACHE BOOL "")
   set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "")

--- a/lvk/CMakeLists.txt
+++ b/lvk/CMakeLists.txt
@@ -26,7 +26,10 @@ lvk_set_folder(LVKLibrary "LVK")
 
 add_subdirectory(vulkan)
 
-target_link_libraries(LVKLibrary PUBLIC LVKVulkan glfw)
+target_link_libraries(LVKLibrary PUBLIC LVKVulkan)
+if(LVK_WITH_GLFW)
+  target_link_libraries(LVKLibrary PUBLIC glfw)
+endif()
 
 if(APPLE)
   target_link_libraries(LVKLibrary PRIVATE "-framework Metal" "-framework AppKit" "-framework Foundation" "-framework QuartzCore")

--- a/lvk/LVK.cpp
+++ b/lvk/LVK.cpp
@@ -12,6 +12,7 @@
 #define NOMINMAX
 #define WIN32_LEAN_AND_MEAN
 
+#if LVK_WITH_GLFW
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
@@ -28,6 +29,7 @@
 // clang-format on
 
 #include <GLFW/glfw3native.h>
+#endif // LVK_WITH_GLFW
 
 #include <lvk/vulkan/VulkanClasses.h>
 
@@ -79,7 +81,7 @@ static constexpr TextureFormatProperties properties[] = {
 
 } // namespace
 
-#if __APPLE__
+#if __APPLE__ && LVK_WITH_GLFW
 void* createCocoaWindowView(GLFWwindow* window);
 #endif
 
@@ -190,6 +192,7 @@ void lvk::logShaderSource(const char* text) {
   LLOGL("\n");
 }
 
+#if LVK_WITH_GLFW
 GLFWwindow* lvk::initWindow(const char* windowTitle, int& outWidth, int& outHeight, bool resizable) {
   if (!glfwInit()) {
     return nullptr;
@@ -307,3 +310,4 @@ std::unique_ptr<lvk::IContext> lvk::createVulkanContextWithSwapchain(GLFWwindow*
 
   return std::move(ctx);
 }
+#endif // LVK_WITH_GLFW

--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -838,7 +838,9 @@ class IContext {
 
 } // namespace lvk
 
+#if LVK_WITH_GLFW
 typedef struct GLFWwindow GLFWwindow;
+#endif
 
 namespace lvk {
 
@@ -856,6 +858,7 @@ struct ContextConfig {
 [[nodiscard]] uint32_t getTextureBytesPerLayer(uint32_t width, uint32_t height, lvk::Format format, uint32_t level);
 void logShaderSource(const char* text);
 
+#if LVK_WITH_GLFW
 /*
  * width/height  > 0: window size in pixels
  * width/height == 0: take the whole monitor work area
@@ -868,5 +871,6 @@ std::unique_ptr<lvk::IContext> createVulkanContextWithSwapchain(GLFWwindow* wind
                                                                 uint32_t height,
                                                                 const lvk::ContextConfig& cfg,
                                                                 lvk::HWDeviceType preferredDeviceType = lvk::HWDeviceType_Discrete);
+#endif
 
 } // namespace lvk

--- a/lvk/LVK.mm
+++ b/lvk/LVK.mm
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#if LVK_WITH_GLFW
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
 
@@ -36,3 +37,4 @@ void* createCocoaWindowView(GLFWwindow* window) {
 
   return nswindow.contentView;
 }
+#endif // LVK_WITH_GLFW

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-set(PROJECT_NAME "IGL Samples")
+set(PROJECT_NAME "LVK Samples")
 
 if(MSVC)
   add_definitions(-D_CONSOLE)


### PR DESCRIPTION
It can be helpful to make LVK not dependent on GLFW in some cases:
1. For platforms that don't support GLFW (e.g. iOS/Android)
2. Use custom GLFW builds for desktop