### PR TITLE
Fix assert by VK_ERROR_OUT_OF_DATE_KHR on resizing

### DIFF
--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -1443,7 +1443,7 @@ lvk::TextureHandle lvk::VulkanSwapchain::getCurrentTexture() {
   if (getNextImage_) {
     // when timeout is set to UINT64_MAX, we wait until the next image has been acquired
     VkResult r = vkAcquireNextImageKHR(device_, swapchain_, UINT64_MAX, acquireSemaphore_, VK_NULL_HANDLE, &currentImageIndex_);
-    if (r != VK_SUCCESS && r != VK_SUBOPTIMAL_KHR) {
+    if (r != VK_SUCCESS && r != VK_SUBOPTIMAL_KHR && r != VK_ERROR_OUT_OF_DATE_KHR) {
       VK_ASSERT(r);
     }
     getNextImage_ = false;
@@ -1477,7 +1477,7 @@ lvk::Result lvk::VulkanSwapchain::present(VkSemaphore waitSemaphore) {
       .pImageIndices = &currentImageIndex_,
   };
   VkResult r = vkQueuePresentKHR(graphicsQueue_, &pi);
-  if (r != VK_SUCCESS && r != VK_SUBOPTIMAL_KHR) {
+  if (r != VK_SUCCESS && r != VK_SUBOPTIMAL_KHR && r != VK_ERROR_OUT_OF_DATE_KHR) {
     VK_ASSERT(r);
   }
   LVK_PROFILER_ZONE_END();


### PR DESCRIPTION
It's not fatal error, swapchain can be recreated

> VK_ERROR_OUT_OF_DATE_KHR A surface has changed in such a way that it is no longer compatible with the swapchain, and further presentation requests using the swapchain will fail. Applications must query the new surface properties and recreate their swapchain if they wish to continue presenting to the surface.

https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkResult.html