### PR TITLE
Fix shader source logging

### DIFF
--- a/lvk/LVK.cpp
+++ b/lvk/LVK.cpp
@@ -181,20 +181,33 @@ void lvk::destroy(lvk::IContext* ctx, lvk::TextureHandle handle) {
 // Logs GLSL shaders with line numbers annotation
 void lvk::logShaderSource(const char* text) {
   uint32_t line = 1;
-
-  LLOGL("\n(%3u) ", line);
-
+  
+  constexpr uint32_t kBufferLength = 8192;
+  char buffer[kBufferLength];
+  
+  auto offset = snprintf(buffer, kBufferLength, "\n(%3u) ", line);
+  assert(offset + 2 < kBufferLength);
+  
   while (text && *text) {
     if (*text == '\n') {
-      LLOGL("\n(%3u) ", ++line);
+      buffer[offset++] = '\n';
+      buffer[offset++] = 0;
+      LLOGL(buffer);
+
+      offset = snprintf(buffer, kBufferLength, "(%3u) ", ++line);
+      assert(offset + 2 < kBufferLength);
     } else if (*text == '\r') {
       // skip it to support Windows/UNIX EOLs
     } else {
-      LLOGL("%c", *text);
+      if (offset + 2 < kBufferLength) {
+        buffer[offset++] = *text;
+      }
     }
     text++;
   }
-  LLOGL("\n");
+  buffer[offset++] = '\n';
+  buffer[offset++] = 0;
+  LLOGL(buffer);
 }
 
 #if LVK_WITH_GLFW


### PR DESCRIPTION
Previously shader source was logged by one character per line in case output to html file via minilog.

# Before:
<img width="1332" alt="Снимок экрана 2023-09-25 в 23 20 02" src="https://github.com/corporateshark/lightweightvk/assets/5437220/221c1c67-985c-4c8a-b85f-7945b76c3439">

# After:
<img width="1334" alt="Снимок экрана 2023-09-25 в 23 20 43" src="https://github.com/corporateshark/lightweightvk/assets/5437220/b334a5ec-b0c6-401e-ba6d-bdfbf18978d7">
