### PR TITLE
Create `VkPipelineLayout` object per each individual LVK pipeline state

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -48,18 +48,6 @@ jobs:
         run: |
           cmake -G "Unix Makefiles" -S "${{ github.workspace }}" -B build -DLVK_WITH_SAMPLES_ANDROID=ON
 
-      - name: Assemble HelloTriangle APK
-        run: |
-          cd build/android/HelloTriangle
-          chmod +x ./gradlew
-          ./gradlew assembleDebug
-
-      - name: Assemble Tiny APK
-        run: |
-          cd build/android/Tiny
-          chmod +x ./gradlew
-          ./gradlew assembleDebug
-
       - name: Assemble Tiny_Mesh APK
         run: |
           cd build/android/Tiny_Mesh

--- a/lvk/vulkan/CMakeLists.txt
+++ b/lvk/vulkan/CMakeLists.txt
@@ -35,6 +35,12 @@ lvk_set_folder(SPIRV              "third-party/glslang")
 lvk_set_folder(glslang-default-resource-limits "third-party/glslang")
 # cmake-format: on
 
+# SPIRV-Reflect
+set(SPIRV_REFLECT_EXECUTABLE OFF CACHE BOOL "")
+set(SPIRV_REFLECT_STATIC_LIB ON  CACHE BOOL "")
+add_subdirectory(${LVK_ROOT_DIR}/third-party/deps/src/SPIRV-Reflect "SPIRV-Reflect")
+lvk_set_folder(spirv-reflect-static "third-party")
+
 if(NOT LVK_USE_CUSTOM_MOLTENVK)
   find_package(Vulkan REQUIRED)
 endif()
@@ -45,6 +51,8 @@ endif()
 
 target_link_libraries(LVKVulkan PRIVATE LVKLibrary)
 target_link_libraries(LVKVulkan PRIVATE glslang SPIRV glslang-default-resource-limits)
+target_link_libraries(LVKVulkan PRIVATE spirv-reflect-static)
+
 if(LVK_USE_CUSTOM_MOLTENVK)
   target_include_directories(LVKVulkan PUBLIC "${LVK_CUSTOM_MOLTENVK_PATH}/include")
   target_link_libraries(LVKVulkan PUBLIC "${LVK_CUSTOM_MOLTENVK_PATH}/dylib/macOS/libMoltenVK.dylib")

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -2107,13 +2107,21 @@ void lvk::CommandBuffer::cmdBindComputePipeline(lvk::ComputePipelineHandle handl
     return;
   }
 
+  currentPipelineGraphics_ = {};
+  currentPipelineCompute_ = handle;
+
   VkPipeline pipeline = ctx_->getVkPipeline(handle);
 
+  const lvk::ComputePipelineState* cps = ctx_->computePipelinesPool_.get(handle);
+
+  LVK_ASSERT(cps);
   LVK_ASSERT(pipeline != VK_NULL_HANDLE);
 
   if (lastPipelineBound_ != pipeline) {
     lastPipelineBound_ = pipeline;
     vkCmdBindPipeline(wrapper_->cmdBuf_, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
+    ctx_->checkAndUpdateDescriptorSets();
+    ctx_->bindDefaultDescriptorSets(wrapper_->cmdBuf_, VK_PIPELINE_BIND_POINT_COMPUTE, cps->pipelineLayout_);
   }
 }
 
@@ -2129,9 +2137,6 @@ void lvk::CommandBuffer::cmdDispatchThreadGroups(const Dimensions& threadgroupCo
     bufferBarrier(
         deps.buffers[i], VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
   }
-
-  ctx_->checkAndUpdateDescriptorSets();
-  ctx_->bindDefaultDescriptorSets(wrapper_->cmdBuf_, VK_PIPELINE_BIND_POINT_COMPUTE);
 
   vkCmdDispatch(wrapper_->cmdBuf_, threadgroupCount.width, threadgroupCount.height, threadgroupCount.depth);
 }
@@ -2389,7 +2394,6 @@ void lvk::CommandBuffer::cmdBeginRendering(const lvk::RenderPass& renderPass, co
   cmdBindDepthState({});
 
   ctx_->checkAndUpdateDescriptorSets();
-  ctx_->bindDefaultDescriptorSets(wrapper_->cmdBuf_, VK_PIPELINE_BIND_POINT_GRAPHICS);
 
   vkCmdSetDepthCompareOp(wrapper_->cmdBuf_, VK_COMPARE_OP_ALWAYS);
   vkCmdSetDepthBiasEnable(wrapper_->cmdBuf_, VK_FALSE);
@@ -2449,7 +2453,8 @@ void lvk::CommandBuffer::cmdBindRenderPipeline(lvk::RenderPipelineHandle handle)
     return;
   }
 
-  currentPipeline_ = handle;
+  currentPipelineGraphics_ = handle;
+  currentPipelineCompute_ = {};
 
   const lvk::RenderPipelineState* rps = ctx_->renderPipelinesPool_.get(handle);
 
@@ -2463,13 +2468,14 @@ void lvk::CommandBuffer::cmdBindRenderPipeline(lvk::RenderPipelineHandle handle)
     LLOGW("Make sure your render pass and render pipeline both have matching depth attachments");
   }
 
-  VkPipeline pipeline = ctx_->getVkPipeline(currentPipeline_);
+  VkPipeline pipeline = ctx_->getVkPipeline(handle);
 
   LVK_ASSERT(pipeline != VK_NULL_HANDLE);
 
   if (lastPipelineBound_ != pipeline) {
     lastPipelineBound_ = pipeline;
     vkCmdBindPipeline(wrapper_->cmdBuf_, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
+    ctx_->bindDefaultDescriptorSets(wrapper_->cmdBuf_, VK_PIPELINE_BIND_POINT_GRAPHICS, rps->pipelineLayout_);
   }
 }
 
@@ -2525,11 +2531,20 @@ void lvk::CommandBuffer::cmdPushConstants(const void* data, size_t size, size_t 
     LLOGW("Push constants size exceeded %u (max %u bytes)", size + offset, limits.maxPushConstantsSize);
   }
 
-  const VkShaderStageFlags shaderStageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
-                                              VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_FRAGMENT_BIT |
-                                              VK_SHADER_STAGE_COMPUTE_BIT;
+  if (currentPipelineGraphics_.empty() && currentPipelineCompute_.empty()) {
+    LVK_ASSERT_MSG(false, "No pipeline bound - cannot set push constants");
+    return;
+  }
 
-  vkCmdPushConstants(wrapper_->cmdBuf_, ctx_->vkPipelineLayout_, shaderStageFlags, (uint32_t)offset, (uint32_t)size, data);
+  const lvk::RenderPipelineState* stateGraphics = ctx_->renderPipelinesPool_.get(currentPipelineGraphics_);
+  const lvk::ComputePipelineState* stateCompute = ctx_->computePipelinesPool_.get(currentPipelineCompute_);
+
+  LVK_ASSERT(stateGraphics || stateCompute);
+
+  VkPipelineLayout layout = stateGraphics ? stateGraphics->pipelineLayout_ : stateCompute->pipelineLayout_;
+  VkShaderStageFlags shaderStageFlags = stateGraphics ? stateGraphics->shaderStageFlags_ : VK_SHADER_STAGE_COMPUTE_BIT;
+
+  vkCmdPushConstants(wrapper_->cmdBuf_, layout, shaderStageFlags, (uint32_t)offset, (uint32_t)size, data);
 }
 
 void lvk::CommandBuffer::cmdDraw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t baseInstance) {
@@ -3155,7 +3170,6 @@ lvk::VulkanContext::~VulkanContext() {
   immediate_.reset(nullptr);
 
   vkDestroyDescriptorSetLayout(vkDevice_, vkDSL_, nullptr);
-  vkDestroyPipelineLayout(vkDevice_, vkPipelineLayout_, nullptr);
   vkDestroyDescriptorPool(vkDevice_, vkDPool_, nullptr);
   vkDestroySurfaceKHR(vkInstance_, vkSurface_, nullptr);
   vkDestroyPipelineCache(vkDevice_, pipelineCache_, nullptr);
@@ -3519,6 +3533,8 @@ VkPipeline lvk::VulkanContext::getVkPipeline(RenderPipelineHandle handle) {
   if (rps->lastVkDescriptorSetLayout_ != vkDSL_) {
     deferredTask(std::packaged_task<void()>(
         [device = getVkDevice(), pipeline = rps->pipeline_]() { vkDestroyPipeline(device, pipeline, nullptr); }));
+    deferredTask(std::packaged_task<void()>(
+        [device = getVkDevice(), layout = rps->pipelineLayout_]() { vkDestroyPipelineLayout(device, layout, nullptr); }));
     rps->pipeline_ = VK_NULL_HANDLE;
     rps->lastVkDescriptorSetLayout_ = vkDSL_;
   }
@@ -3529,6 +3545,7 @@ VkPipeline lvk::VulkanContext::getVkPipeline(RenderPipelineHandle handle) {
 
   // build a new Vulkan pipeline
 
+  VkPipelineLayout layout = VK_NULL_HANDLE;
   VkPipeline pipeline = VK_NULL_HANDLE;
 
   const RenderPipelineDesc& desc = rps->desc_;
@@ -3595,6 +3612,52 @@ VkPipeline lvk::VulkanContext::getVkPipeline(RenderPipelineHandle handle) {
 
   const VkSpecializationInfo si = lvk::getPipelineShaderStageSpecializationInfo(desc.specInfo, entries);
 
+  // create pipeline layout
+  {
+#define UPDATE_PUSH_CONSTANT_SIZE(sm, bit)                                  \
+  if (sm) {                                                                 \
+    pushConstantsSize = std::max(pushConstantsSize, sm->pushConstantsSize); \
+    rps->shaderStageFlags_ |= bit;                                          \
+  }
+    rps->shaderStageFlags_ = 0;
+    uint32_t pushConstantsSize = 0;
+    UPDATE_PUSH_CONSTANT_SIZE(vertModule, VK_SHADER_STAGE_VERTEX_BIT);
+    UPDATE_PUSH_CONSTANT_SIZE(tescModule, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
+    UPDATE_PUSH_CONSTANT_SIZE(teseModule, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT);
+    UPDATE_PUSH_CONSTANT_SIZE(geomModule, VK_SHADER_STAGE_GEOMETRY_BIT);
+    UPDATE_PUSH_CONSTANT_SIZE(fragModule, VK_SHADER_STAGE_FRAGMENT_BIT);
+#undef UPDATE_PUSH_CONSTANT_SIZE
+
+    // maxPushConstantsSize is guaranteed to be at least 128 bytes
+    // https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#features-limits
+    // Table 32. Required Limits
+    const VkPhysicalDeviceLimits& limits = getVkPhysicalDeviceProperties().limits;
+    if (!LVK_VERIFY(pushConstantsSize <= limits.maxPushConstantsSize)) {
+      LLOGW("Push constants size exceeded %u (max %u bytes)", pushConstantsSize, limits.maxPushConstantsSize);
+    }
+
+    // duplicate for MoltenVK
+    const VkDescriptorSetLayout dsls[] = {vkDSL_, vkDSL_, vkDSL_, vkDSL_};
+    const VkPushConstantRange range = {
+        .stageFlags = rps->shaderStageFlags_,
+        .offset = 0,
+        .size = pushConstantsSize,
+    };
+    const VkPipelineLayoutCreateInfo ci = {
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .setLayoutCount = (uint32_t)LVK_ARRAY_NUM_ELEMENTS(dsls),
+        .pSetLayouts = dsls,
+        .pushConstantRangeCount = pushConstantsSize ? 1u : 0u,
+        .pPushConstantRanges = pushConstantsSize ? &range : nullptr,
+    };
+    VK_ASSERT(vkCreatePipelineLayout(vkDevice_, &ci, nullptr, &layout));
+    char pipelineLayoutName[256] = {0};
+    if (rps->desc_.debugName) {
+      snprintf(pipelineLayoutName, sizeof(pipelineLayoutName) - 1, "Pipeline Layout: %s", rps->desc_.debugName);
+    }
+    VK_ASSERT(lvk::setDebugObjectName(vkDevice_, VK_OBJECT_TYPE_PIPELINE_LAYOUT, (uint64_t)layout, pipelineLayoutName));
+  }
+
   lvk::VulkanPipelineBuilder()
       // from Vulkan 1.0
       .dynamicState(VK_DYNAMIC_STATE_VIEWPORT)
@@ -3640,9 +3703,10 @@ VkPipeline lvk::VulkanContext::getVkPipeline(RenderPipelineHandle handle) {
       .depthAttachmentFormat(formatToVkFormat(desc.depthFormat))
       .stencilAttachmentFormat(formatToVkFormat(desc.stencilFormat))
       .patchControlPoints(desc.patchControlPoints)
-      .build(vkDevice_, pipelineCache_, vkPipelineLayout_, &pipeline, desc.debugName);
+      .build(vkDevice_, pipelineCache_, layout, &pipeline, desc.debugName);
 
   rps->pipeline_ = pipeline;
+  rps->pipelineLayout_ = layout;
 
   return pipeline;
 }
@@ -3657,7 +3721,10 @@ VkPipeline lvk::VulkanContext::getVkPipeline(ComputePipelineHandle handle) {
   if (cps->lastVkDescriptorSetLayout_ != vkDSL_) {
     deferredTask(
         std::packaged_task<void()>([device = vkDevice_, pipeline = cps->pipeline_]() { vkDestroyPipeline(device, pipeline, nullptr); }));
+    deferredTask(
+        std::packaged_task<void()>([device = vkDevice_, layout = cps->pipelineLayout_]() { vkDestroyPipelineLayout(device, layout, nullptr); }));
     cps->pipeline_ = VK_NULL_HANDLE;
+    cps->pipelineLayout_ = VK_NULL_HANDLE;
     cps->lastVkDescriptorSetLayout_ = vkDSL_;
   }
 
@@ -3670,11 +3737,35 @@ VkPipeline lvk::VulkanContext::getVkPipeline(ComputePipelineHandle handle) {
 
     const VkSpecializationInfo siComp = lvk::getPipelineShaderStageSpecializationInfo(cps->desc_.specInfo, entries);
 
+    // create pipeline layout
+    {
+      // duplicate for MoltenVK
+      const VkDescriptorSetLayout dsls[] = {vkDSL_, vkDSL_, vkDSL_, vkDSL_};
+      const VkPushConstantRange range = {
+          .stageFlags = VK_SHADER_STAGE_COMPUTE_BIT,
+          .offset = 0,
+          .size = sm->pushConstantsSize,
+      };
+      const VkPipelineLayoutCreateInfo ci = {
+          .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+          .setLayoutCount = (uint32_t)LVK_ARRAY_NUM_ELEMENTS(dsls),
+          .pSetLayouts = dsls,
+          .pushConstantRangeCount = 1,
+          .pPushConstantRanges = &range,
+      };
+      VK_ASSERT(vkCreatePipelineLayout(vkDevice_, &ci, nullptr, &cps->pipelineLayout_));
+      char pipelineLayoutName[256] = {0};
+      if (cps->desc_.debugName) {
+        snprintf(pipelineLayoutName, sizeof(pipelineLayoutName) - 1, "Pipeline Layout: %s", cps->desc_.debugName);
+      }
+      VK_ASSERT(lvk::setDebugObjectName(vkDevice_, VK_OBJECT_TYPE_PIPELINE_LAYOUT, (uint64_t)cps->pipelineLayout_, pipelineLayoutName));
+    }
+
     const VkComputePipelineCreateInfo ci = {
         .sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO,
         .flags = 0,
         .stage = lvk::getPipelineShaderStageCreateInfo(VK_SHADER_STAGE_COMPUTE_BIT, sm->sm, cps->desc_.entryPoint, &siComp),
-        .layout = vkPipelineLayout_,
+        .layout = cps->pipelineLayout_,
         .basePipelineHandle = VK_NULL_HANDLE,
         .basePipelineIndex = -1,
     };
@@ -3748,6 +3839,8 @@ void lvk::VulkanContext::destroy(lvk::ComputePipelineHandle handle) {
 
   deferredTask(
       std::packaged_task<void()>([device = getVkDevice(), pipeline = cps->pipeline_]() { vkDestroyPipeline(device, pipeline, nullptr); }));
+  deferredTask(std::packaged_task<void()>(
+      [device = getVkDevice(), layout = cps->pipelineLayout_]() { vkDestroyPipelineLayout(device, layout, nullptr); }));
 
   computePipelinesPool_.destroy(handle);
 }
@@ -3761,6 +3854,8 @@ void lvk::VulkanContext::destroy(lvk::RenderPipelineHandle handle) {
 
   deferredTask(
       std::packaged_task<void()>([device = getVkDevice(), pipeline = rps->pipeline_]() { vkDestroyPipeline(device, pipeline, nullptr); }));
+  deferredTask(std::packaged_task<void()>(
+      [device = getVkDevice(), layout = rps->pipelineLayout_]() { vkDestroyPipelineLayout(device, layout, nullptr); }));
 
   renderPipelinesPool_.destroy(handle);
 }
@@ -4941,10 +5036,6 @@ lvk::Result lvk::VulkanContext::growDescriptorPool(uint32_t maxTextures, uint32_
   if (vkDPool_ != VK_NULL_HANDLE) {
     deferredTask(std::packaged_task<void()>([device = vkDevice_, dp = vkDPool_]() { vkDestroyDescriptorPool(device, dp, nullptr); }));
   }
-  if (vkPipelineLayout_ != VK_NULL_HANDLE) {
-    deferredTask(std::packaged_task<void()>(
-        [device = vkDevice_, layout = vkPipelineLayout_]() { vkDestroyPipelineLayout(device, layout, nullptr); }));
-  }
 
   // create default descriptor set layout which is going to be shared by graphics pipelines
   const VkDescriptorSetLayoutBinding bindings[kBinding_NumBindings] = {
@@ -4998,37 +5089,6 @@ lvk::Result lvk::VulkanContext::growDescriptorPool(uint32_t maxTextures, uint32_
     VK_ASSERT_RETURN(vkAllocateDescriptorSets(vkDevice_, &ai, &vkDSet_));
   }
 
-  // create pipeline layout
-  {
-    // maxPushConstantsSize is guaranteed to be at least 128 bytes
-    // https://www.khronos.org/registry/vulkan/specs/1.3/html/vkspec.html#features-limits
-    // Table 32. Required Limits
-    const uint32_t kPushConstantsSize = 128;
-    const VkPhysicalDeviceLimits& limits = getVkPhysicalDeviceProperties().limits;
-    if (!LVK_VERIFY(kPushConstantsSize <= limits.maxPushConstantsSize)) {
-      LLOGW("Push constants size exceeded %u (max %u bytes)", kPushConstantsSize, limits.maxPushConstantsSize);
-    }
-
-    // duplicate for MoltenVK
-    const VkDescriptorSetLayout dsls[] = {vkDSL_, vkDSL_, vkDSL_, vkDSL_};
-    const VkPushConstantRange range = {
-        .stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |
-                      VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_COMPUTE_BIT,
-        .offset = 0,
-        .size = kPushConstantsSize,
-    };
-    const VkPipelineLayoutCreateInfo ci = {
-        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
-        .setLayoutCount = (uint32_t)LVK_ARRAY_NUM_ELEMENTS(dsls),
-        .pSetLayouts = dsls,
-        .pushConstantRangeCount = 1,
-        .pPushConstantRanges = &range,
-    };
-    VK_ASSERT(vkCreatePipelineLayout(vkDevice_, &ci, nullptr, &vkPipelineLayout_));
-    VK_ASSERT(lvk::setDebugObjectName(
-        vkDevice_, VK_OBJECT_TYPE_PIPELINE_LAYOUT, (uint64_t)vkPipelineLayout_, "Pipeline Layout: VulkanContext::pipelineLayout_"));
-  }
-
   return Result();
 }
 
@@ -5075,10 +5135,10 @@ std::shared_ptr<lvk::VulkanImage> lvk::VulkanContext::createImage(VkImageType im
       *this, vkDevice_, extent, imageType, format, numLevels, numLayers, tiling, usageFlags, memFlags, flags, samples, debugName);
 }
 
-void lvk::VulkanContext::bindDefaultDescriptorSets(VkCommandBuffer cmdBuf, VkPipelineBindPoint bindPoint) const {
+void lvk::VulkanContext::bindDefaultDescriptorSets(VkCommandBuffer cmdBuf, VkPipelineBindPoint bindPoint, VkPipelineLayout layout) const {
   LVK_PROFILER_FUNCTION();
   const VkDescriptorSet dsets[4] = {vkDSet_, vkDSet_, vkDSet_, vkDSet_};
-  vkCmdBindDescriptorSets(cmdBuf, bindPoint, vkPipelineLayout_, 0, (uint32_t)LVK_ARRAY_NUM_ELEMENTS(dsets), dsets, 0, nullptr);
+  vkCmdBindDescriptorSets(cmdBuf, bindPoint, layout, 0, (uint32_t)LVK_ARRAY_NUM_ELEMENTS(dsets), dsets, 0, nullptr);
 }
 
 void lvk::VulkanContext::checkAndUpdateDescriptorSets() {

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -3516,11 +3516,11 @@ VkPipeline lvk::VulkanContext::getVkPipeline(RenderPipelineHandle handle) {
     return VK_NULL_HANDLE;
   }
 
-  if (rps->pipelineLayout_ != vkPipelineLayout_) {
+  if (rps->lastVkDescriptorSetLayout_ != vkDSL_) {
     deferredTask(std::packaged_task<void()>(
         [device = getVkDevice(), pipeline = rps->pipeline_]() { vkDestroyPipeline(device, pipeline, nullptr); }));
     rps->pipeline_ = VK_NULL_HANDLE;
-    rps->pipelineLayout_ = vkPipelineLayout_;
+    rps->lastVkDescriptorSetLayout_ = vkDSL_;
   }
 
   if (rps->pipeline_ != VK_NULL_HANDLE) {
@@ -3654,11 +3654,11 @@ VkPipeline lvk::VulkanContext::getVkPipeline(ComputePipelineHandle handle) {
     return VK_NULL_HANDLE;
   }
 
-  if (cps->pipelineLayout_ != vkPipelineLayout_) {
+  if (cps->lastVkDescriptorSetLayout_ != vkDSL_) {
     deferredTask(
         std::packaged_task<void()>([device = vkDevice_, pipeline = cps->pipeline_]() { vkDestroyPipeline(device, pipeline, nullptr); }));
     cps->pipeline_ = VK_NULL_HANDLE;
-    cps->pipelineLayout_ = vkPipelineLayout_;
+    cps->lastVkDescriptorSetLayout_ = vkDSL_;
   }
 
   if (cps->pipeline_ == VK_NULL_HANDLE) {

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -266,11 +266,11 @@ struct RenderPipelineState final {
   VkVertexInputBindingDescription vkBindings_[VertexInput::LVK_VERTEX_BUFFER_MAX] = {};
   VkVertexInputAttributeDescription vkAttributes_[VertexInput::LVK_VERTEX_ATTRIBUTES_MAX] = {};
 
-  //VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
-
   // non-owning, the last seen VkDescriptorSetLayout from VulkanContext::vkDSL_ (if the context has a new layout, invalidate all VkPipeline objects)
   VkDescriptorSetLayout lastVkDescriptorSetLayout_ = VK_NULL_HANDLE;
 
+  VkShaderStageFlags shaderStageFlags_ = 0;
+  VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
   VkPipeline pipeline_ = VK_NULL_HANDLE;
 };
 
@@ -338,11 +338,10 @@ class VulkanPipelineBuilder final {
 struct ComputePipelineState final {
   ComputePipelineDesc desc_;
 
-  // VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
-
   // non-owning, the last seen VkDescriptorSetLayout from VulkanContext::vkDSL_ (invalidate all VkPipeline objects on new layout)
   VkDescriptorSetLayout lastVkDescriptorSetLayout_ = VK_NULL_HANDLE;
 
+  VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
   VkPipeline pipeline_ = VK_NULL_HANDLE;
 };
 
@@ -427,7 +426,8 @@ class CommandBuffer final : public ICommandBuffer {
 
   bool isRendering_ = false;
 
-  lvk::RenderPipelineHandle currentPipeline_ = {};
+  lvk::RenderPipelineHandle currentPipelineGraphics_ = {};
+  lvk::ComputePipelineHandle currentPipelineCompute_ = {};
 };
 
 class VulkanStagingDevice final {
@@ -590,7 +590,7 @@ class VulkanContext final : public IContext {
   void* getVmaAllocator() const;
 
   void checkAndUpdateDescriptorSets();
-  void bindDefaultDescriptorSets(VkCommandBuffer cmdBuf, VkPipelineBindPoint bindPoint) const;
+  void bindDefaultDescriptorSets(VkCommandBuffer cmdBuf, VkPipelineBindPoint bindPoint, VkPipelineLayout layout) const;
 
   // for shaders debugging
   void invokeShaderModuleErrorCallback(int line, int col, const char* debugName, VkShaderModule sm);
@@ -645,7 +645,6 @@ class VulkanContext final : public IContext {
   std::unique_ptr<lvk::VulkanStagingDevice> stagingDevice_;
   uint32_t currentMaxTextures_ = 16;
   uint32_t currentMaxSamplers_ = 16;
-  VkPipelineLayout vkPipelineLayout_ = VK_NULL_HANDLE;
   VkDescriptorSetLayout vkDSL_ = VK_NULL_HANDLE;
   VkDescriptorPool vkDPool_ = VK_NULL_HANDLE;
   VkDescriptorSet vkDSet_ = VK_NULL_HANDLE;

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -341,6 +341,11 @@ struct ComputePipelineState final {
   VkPipeline pipeline_ = VK_NULL_HANDLE;
 };
 
+struct ShaderModuleState final {
+  VkShaderModule sm = VK_NULL_HANDLE;
+  uint32_t pushConstantsSize = 0;
+};
+
 class CommandBuffer final : public ICommandBuffer {
  public:
   CommandBuffer() = default;
@@ -516,7 +521,7 @@ class VulkanContext final : public IContext {
   ColorSpace getSwapChainColorSpace() const override;
   uint32_t getNumSwapchainImages() const override;
   void recreateSwapchain(int newWidth, int newHeight) override;
-  
+
   uint32_t getFramebufferMSAABitMask() const override;
 
   double getTimestampPeriodToMs() const override;
@@ -592,8 +597,8 @@ class VulkanContext final : public IContext {
   void processDeferredTasks() const;
   void waitDeferredTasks();
   lvk::Result growDescriptorPool(uint32_t maxTextures, uint32_t maxSamplers);
-  VkShaderModule createShaderModuleFromSPIRV(const void* spirv, size_t numBytes, const char* debugName, Result* outResult) const;
-  VkShaderModule createShaderModuleFromGLSL(ShaderStage stage, const char* source, const char* debugName, Result* outResult) const;
+  ShaderModuleState createShaderModuleFromSPIRV(const void* spirv, size_t numBytes, const char* debugName, Result* outResult) const;
+  ShaderModuleState createShaderModuleFromGLSL(ShaderStage stage, const char* source, const char* debugName, Result* outResult) const;
 
  private:
   friend class lvk::VulkanSwapchain;
@@ -651,7 +656,7 @@ class VulkanContext final : public IContext {
 
   lvk::ContextConfig config_;
 
-  lvk::Pool<lvk::ShaderModule, VkShaderModule> shaderModulesPool_;
+  lvk::Pool<lvk::ShaderModule, lvk::ShaderModuleState> shaderModulesPool_;
   lvk::Pool<lvk::RenderPipeline, lvk::RenderPipelineState> renderPipelinesPool_;
   lvk::Pool<lvk::ComputePipeline, lvk::ComputePipelineState> computePipelinesPool_;
   lvk::Pool<lvk::Sampler, VkSampler> samplersPool_;

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -266,8 +266,10 @@ struct RenderPipelineState final {
   VkVertexInputBindingDescription vkBindings_[VertexInput::LVK_VERTEX_BUFFER_MAX] = {};
   VkVertexInputAttributeDescription vkAttributes_[VertexInput::LVK_VERTEX_ATTRIBUTES_MAX] = {};
 
-  // non-owning, cached the last pipeline layout from the context (if the context has a new layout, invalidate all VkPipeline objects)
-  VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
+  //VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
+
+  // non-owning, the last seen VkDescriptorSetLayout from VulkanContext::vkDSL_ (if the context has a new layout, invalidate all VkPipeline objects)
+  VkDescriptorSetLayout lastVkDescriptorSetLayout_ = VK_NULL_HANDLE;
 
   VkPipeline pipeline_ = VK_NULL_HANDLE;
 };
@@ -335,8 +337,11 @@ class VulkanPipelineBuilder final {
 
 struct ComputePipelineState final {
   ComputePipelineDesc desc_;
-  // non-owning, cached the last pipeline layout from the context
-  VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
+
+  // VkPipelineLayout pipelineLayout_ = VK_NULL_HANDLE;
+
+  // non-owning, the last seen VkDescriptorSetLayout from VulkanContext::vkDSL_ (invalidate all VkPipeline objects on new layout)
+  VkDescriptorSetLayout lastVkDescriptorSetLayout_ = VK_NULL_HANDLE;
 
   VkPipeline pipeline_ = VK_NULL_HANDLE;
 };

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -592,8 +592,8 @@ class VulkanContext final : public IContext {
   void processDeferredTasks() const;
   void waitDeferredTasks();
   lvk::Result growDescriptorPool(uint32_t maxTextures, uint32_t maxSamplers);
-  VkShaderModule createShaderModule(const void* data, size_t length, const char* debugName, Result* outResult) const;
-  VkShaderModule createShaderModule(ShaderStage stage, const char* source, const char* debugName, Result* outResult) const;
+  VkShaderModule createShaderModuleFromSPIRV(const void* spirv, size_t numBytes, const char* debugName, Result* outResult) const;
+  VkShaderModule createShaderModuleFromGLSL(ShaderStage stage, const char* source, const char* debugName, Result* outResult) const;
 
  private:
   friend class lvk::VulkanSwapchain;

--- a/lvk/vulkan/VulkanUtils.h
+++ b/lvk/vulkan/VulkanUtils.h
@@ -23,6 +23,8 @@
 
 #include <cassert>
 #include <cstdio>
+#include <vector>
+
 #include <volk.h>
 #include <vk_mem_alloc.h>
 #include <lvk/LVK.h>
@@ -70,10 +72,9 @@ VkResult allocateMemory(VkPhysicalDevice physDev,
                         VkDeviceMemory* outMemory);
 
 glslang_resource_t getGlslangResource(const VkPhysicalDeviceLimits& limits);
-Result compileShader(VkDevice device,
-                     VkShaderStageFlagBits stage,
+Result compileShader(VkShaderStageFlagBits stage,
                      const char* code,
-                     VkShaderModule* outShaderModule,
+                     std::vector<uint8_t>* outSPIRV,
                      const glslang_resource_t* glslLangResource = nullptr);
 
 VkSamplerCreateInfo samplerStateDescToVkSamplerCreateInfo(const lvk::SamplerStateDesc& desc, const VkPhysicalDeviceLimits& limits);

--- a/third-party/bootstrap-deps.json
+++ b/third-party/bootstrap-deps.json
@@ -24,6 +24,14 @@
     }
 },
 {
+    "name": "SPIRV-Reflect",
+    "source": {
+        "type": "git",
+        "url": "https://github.com/KhronosGroup/SPIRV-Reflect.git",
+        "revision": "vulkan-sdk-1.3.275.0"
+    }
+},
+{
     "name": "tinyobjloader",
     "source": {
         "type": "git",


### PR DESCRIPTION
1) Create one `VkPipelineLayout` object per each individual LVK pipeline state (graphics and compute).
2) Use `SPIRV-Reflect` to get the size of push constants.
3) Create push constant ranges based on actual push constants usage in all shaders associated with a pipeline.