### PR TITLE
Store scracth buffer for TLAS updating

### DIFF
--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -321,6 +321,7 @@ struct AccelerationStructure {
   VkAccelerationStructureKHR vkHandle = VK_NULL_HANDLE;
   uint64_t deviceAddress = 0;
   lvk::Holder<lvk::BufferHandle> buffer;
+  lvk::Holder<lvk::BufferHandle> scratchBuffer; // Store only for TLAS
 };
 
 class CommandBuffer final : public ICommandBuffer {


### PR DESCRIPTION
Store scratch buffer after TLAS creation, use this scratch buffer during `cmdUpdateTLAS`, recreate it only if it's required