### PR TITLE
[8] Fixes for AO demo on Android

### DIFF
--- a/samples/007_RayTracingAO.cpp
+++ b/samples/007_RayTracingAO.cpp
@@ -393,7 +393,7 @@ std::vector<lvk::Holder<lvk::BufferHandle>> ubPerFrame_, ubPerObject_;
 lvk::RenderPass renderPassOffscreen_;
 lvk::RenderPass renderPassZPrepass_;
 lvk::RenderPass renderPassMain_;
-lvk::Holder<lvk::AccelStructHandle> BLAS;
+std::vector<lvk::Holder<lvk::AccelStructHandle>> BLAS;
 lvk::Holder<lvk::AccelStructHandle> TLAS;
 
 // scene navigation
@@ -564,7 +564,7 @@ void destroy() {
   fbOffscreenDepth_ = nullptr;
   fbOffscreenResolve_ = nullptr;
   TLAS = nullptr;
-  BLAS = nullptr;
+  BLAS.clear();
   sbInstances_ = nullptr;
   ctx_ = nullptr;
 }
@@ -742,7 +742,8 @@ bool initModel() {
       .data = &transformMatrix,
   });
 
-  BLAS = ctx_->createAccelerationStructure({
+  const uint32_t totalPrimitiveCount = (uint32_t)indexData_.size() / 3;
+  lvk::AccelStructDesc blasDesc{
       .type = lvk::AccelStructType_BLAS,
       .geometryType = lvk::AccelStructGeomType_Triangles,
       .vertexFormat = lvk::VertexFormat::Float3,
@@ -752,30 +753,59 @@ bool initModel() {
       .indexFormat = lvk::IndexFormat_UI32,
       .indexBuffer = ib0_,
       .transformBuffer = transformBuffer,
-      .buildRange = {.primitiveCount = (uint32_t)indexData_.size() / 3},
+      .buildRange = {.primitiveCount = totalPrimitiveCount},
       .buildFlags = lvk::AccelStructBuildFlagBits_PreferFastTrace,
       .debugName = "BLAS",
-  });
+  };
+  lvk::AccelStructSizes blasSizes = ctx_->getAccelStructSizes(blasDesc);
+  LLOGL("Full model BLAS sizes buildScratchSize = %llu bytes, accelerationStructureSize = %llu\n",
+        blasSizes.buildScratchSize, blasSizes.accelerationStructureSize);
+  const uint32_t maxStorageBufferSize = ctx_->getMaxStorageBufferSize();
+
+  // Calculate number of BLAS
+  uint32_t requiredBlasCount = 1;
+  if (maxStorageBufferSize != -1) {
+    requiredBlasCount = blasSizes.buildScratchSize / maxStorageBufferSize;
+    const uint32_t cnt = blasSizes.accelerationStructureSize / maxStorageBufferSize;
+    if (cnt > requiredBlasCount)
+      requiredBlasCount = cnt;
+    requiredBlasCount++;
+
+    blasDesc.buildRange.primitiveCount = totalPrimitiveCount / requiredBlasCount;
+  }
+
+  LVK_ASSERT(requiredBlasCount > 0);
+  LLOGL("maxStorageBufferSize = %d bytes, number of BLAS = %d\n", maxStorageBufferSize, requiredBlasCount);
 
   const glm::mat3x4 transform(glm::scale(mat4(1.0f), vec3(0.05f)));
+  BLAS.reserve(requiredBlasCount);
 
-  const lvk::AccelStructInstance instance{
-      // clang-format off
-      .transform = (const lvk::mat3x4&)transform,
-      // clang-format on
-      .instanceCustomIndex = 0,
-      .mask = 0xff,
-      .instanceShaderBindingTableRecordOffset = 0,
-      .flags = lvk::AccelStructInstanceFlagBits_TriangleFacingCullDisable,
-      .accelerationStructureReference = ctx_->gpuAddress(BLAS),
-  };
+  std::vector<lvk::AccelStructInstance> instances;
+  instances.reserve(requiredBlasCount);
+  const uint32_t primitiveCount = blasDesc.buildRange.primitiveCount;
+  for (int i = 0; i < totalPrimitiveCount; i += (int)primitiveCount) {
+    const int rest = (int)totalPrimitiveCount - i;
+    blasDesc.buildRange.primitiveOffset = (uint32_t)i * 3 * sizeof(uint32_t);
+    blasDesc.buildRange.primitiveCount = (primitiveCount < rest) ? primitiveCount : rest;
+    BLAS.emplace_back(ctx_->createAccelerationStructure(blasDesc));
+    instances.emplace_back(lvk::AccelStructInstance{
+        // clang-format off
+        .transform = (const lvk::mat3x4&)transform,
+        // clang-format on
+        .instanceCustomIndex = 0,
+        .mask = 0xff,
+        .instanceShaderBindingTableRecordOffset = 0,
+        .flags = lvk::AccelStructInstanceFlagBits_TriangleFacingCullDisable,
+        .accelerationStructureReference = ctx_->gpuAddress(BLAS.back()),
+    });
+  }
 
   // Buffer for instance data
   sbInstances_ = ctx_->createBuffer(lvk::BufferDesc{
       .usage = lvk::BufferUsageBits_AccelStructBuildInputReadOnly,
       .storage = lvk::StorageType_HostVisible,
-      .size = sizeof(lvk::AccelStructInstance),
-      .data = &instance,
+      .size = sizeof(lvk::AccelStructInstance) * instances.size(),
+      .data = instances.data(),
       .debugName = "sbInstances_",
   });
 
@@ -783,7 +813,7 @@ bool initModel() {
       .type = lvk::AccelStructType_TLAS,
       .geometryType = lvk::AccelStructGeomType_Instances,
       .instancesBuffer = sbInstances_,
-      .buildRange = {.primitiveCount = 1},
+      .buildRange = {.primitiveCount = (uint32_t)instances.size()},
       .buildFlags = lvk::AccelStructBuildFlagBits_PreferFastTrace,
   });
 


### PR DESCRIPTION
## Fixes:
1. Acceleration structures and scratch buffers should fit into storage buffers, so we need to respect max size of storage buffer
2. DebugUtils extension doesn't work without enabled validation layers on Mali Immortalis 

### Samsung Xclipse 940
Driver info: Samsung Proprietary driver Revision: 8e918d4d17 
![Screenshot_20250128_121818](https://github.com/user-attachments/assets/97ce8a36-3d3f-45ed-ac6f-2349d5bfaa92)
![Screenshot_20250128_145746](https://github.com/user-attachments/assets/692e08fe-8fbd-46a5-b448-80b980c83bd4)

### Mali-G715-Immortalis MC11
Driver info: Mali-G715-Immortalis MC11 v1.r38p1-01eac0.c1a71ccca2acf211eb87c5db5322f569
![Screenshot_2025-01-28-15-24-08-410_org lvk samples lvk_007_RayTracingAO](https://github.com/user-attachments/assets/a431a939-4fb6-46d7-b27b-d11f7a90b71f)
![Screenshot_2025-01-28-15-19-47-794_org lvk samples lvk_007_RayTracingAO](https://github.com/user-attachments/assets/a69b0c7a-a8f7-497c-a645-16379475d37f)
