### PR TITLE
[9] Fix validation issues for RT pipelines

### DIFF
--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -755,6 +755,7 @@ struct BufferDesc final {
   uint8_t usage = 0;
   StorageType storage = StorageType_HostVisible;
   size_t size = 0;
+  size_t overwrittenAlignment = 0;
   const void* data = nullptr;
   const char* debugName = "";
 };

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -565,6 +565,7 @@ class VulkanContext final : public IContext {
   BufferHandle createBuffer(VkDeviceSize bufferSize,
                             VkBufferUsageFlags usageFlags,
                             VkMemoryPropertyFlags memFlags,
+                            VkDeviceSize overwrittenAlignment,
                             lvk::Result* outResult,
                             const char* debugName = nullptr);
   SamplerHandle createSampler(const VkSamplerCreateInfo& ci,


### PR DESCRIPTION
NOTE: should be rebased on top of https://github.com/corporateshark/lightweightvk/pull/37

Physical device addresses for acceleration structures and SBT must be aligned by `minAccelerationStructureScratchOffsetAlignment` and `shaderGroupBaseAlignment`. Unfortunately, VMA doesn't allow to do it if multiple buffers with multiple alignment requirements are packs to the same bug buffer.
As a solution, we pass required alignment for acceleration structures and SBT to `createBuffer()` and avoid using VMA in this scenario.

Fixed validation errors:
```
Validation Error: VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03689  
Object 0: handle = 0xb4000077ba804f50, type = VK_OBJECT_TYPE_COMMAND_BUFFER;
MessageID = 0x7d527a 
vkCmdTraceRaysKHR(): pHitShaderBindingTable->deviceAddress (12887524868) must be a multiple of VkPhysicalDeviceRayTracingPipelinePropertiesKHR::shaderGroupBaseAlignment (64).
The Vulkan spec states: pHitShaderBindingTable->deviceAddress must be a multiple of VkPhysicalDeviceRayTracingPipelinePropertiesKHR::shaderGroupBaseAlignment (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03689)                                                                         

Validation Error: VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03710  
Object 0: handle = 0xb4000077ba6e54d0, type = VK_OBJECT_TYPE_COMMAND_BUFFER;
MessageID = 0x63ff8904 
vkCmdBuildAccelerationStructuresKHR(): pInfos[0].scratchData.deviceAddress (12887524100) must be a multiple of minAccelerationStructureScratchOffsetAlignment (256).
The Vulkan spec states: For each element of pInfos, its scratchData.deviceAddress member must be a multiple of VkPhysicalDeviceAccelerationStructurePropertiesKHR::minAccelerationStructureScratchOffsetAlignment
```