### PR TITLE
Fixed BLAS build info: use `geometryFlags` instead of forcing opaque

### DIFF
--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -6289,7 +6289,7 @@ void lvk::VulkanContext::getBuildInfoBLAS(const AccelStructDesc& desc,
                       .transformData = {.deviceAddress = gpuAddress(desc.transformBuffer)},
                   },
           },
-      .flags = VK_GEOMETRY_OPAQUE_BIT_KHR,
+      .flags = geometryFlags,
   };
 
   const VkAccelerationStructureBuildGeometryInfoKHR accelerationBuildGeometryInfo{
@@ -6322,6 +6322,15 @@ void lvk::VulkanContext::getBuildInfoTLAS(const AccelStructDesc& desc,
   LVK_ASSERT(desc.buildRange.primitiveCount);
   LVK_ASSERT(buffersPool_.get(desc.instancesBuffer)->vkUsageFlags_ & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR);
 
+  VkGeometryFlagsKHR geometryFlags = 0;
+
+  if (desc.geometryFlags & AccelStructGeometryFlagBits_Opaque) {
+    geometryFlags |= VK_GEOMETRY_OPAQUE_BIT_KHR;
+  }
+  if (desc.geometryFlags & AccelStructGeometryFlagBits_NoDuplicateAnyHit) {
+    geometryFlags |= VK_GEOMETRY_NO_DUPLICATE_ANY_HIT_INVOCATION_BIT_KHR;
+  }
+
   outGeometry = VkAccelerationStructureGeometryKHR{
       .sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR,
       .geometryType = VK_GEOMETRY_TYPE_INSTANCES_KHR,
@@ -6334,7 +6343,7 @@ void lvk::VulkanContext::getBuildInfoTLAS(const AccelStructDesc& desc,
                       .data = {.deviceAddress = gpuAddress(desc.instancesBuffer)},
                   },
           },
-      .flags = VK_GEOMETRY_OPAQUE_BIT_KHR,
+      .flags = geometryFlags,
   };
 
   const VkAccelerationStructureBuildGeometryInfoKHR accelerationStructureBuildGeometryInfo = {


### PR DESCRIPTION
I tried using an any-hit shader, but it was never called.
After digging a bit, I found that the BLAS was built with the OPAQUE flag forced, and there was an unused variable called `geometryFlags`.
After making these changes, I got the any-hit shader to work.

I also noticed that there is another "hardcoded" OPAQUE flag, but i'm not sure if it is an issue:
https://github.com/corporateshark/lightweightvk/blob/92219fb90b9f2b66bfc13708e60cee5b3fbf7e74/lvk/vulkan/VulkanClasses.cpp#L6337