### PR TITLE
Add buffer copy cmd

### DIFF
--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -1002,7 +1002,7 @@ class ICommandBuffer {
 
   virtual void cmdFillBuffer(BufferHandle buffer, size_t bufferOffset, size_t size, uint32_t data) = 0;
   virtual void cmdUpdateBuffer(BufferHandle buffer, size_t bufferOffset, size_t size, const void* data) = 0;
-  virtual void cmdCopyBuffer(BufferHandle srcBuffer, size_t srcBufferOffset, BufferHandle dstBuffer, size_t dstBufferOffset, size_t size) = 0;
+  virtual void cmdCopyBuffer(BufferHandle srcBuffer, BufferHandle dstBuffer, size_t srcOffset, size_t dstOffset, size_t size) = 0;
   template<typename Struct>
   void cmdUpdateBuffer(BufferHandle buffer, const Struct& data, size_t bufferOffset = 0) {
     this->cmdUpdateBuffer(buffer, bufferOffset, sizeof(Struct), &data);

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -2589,17 +2589,17 @@ void lvk::CommandBuffer::cmdFillBuffer(BufferHandle buffer, size_t bufferOffset,
   bufferBarrier(buffer, VK_PIPELINE_STAGE_2_TRANSFER_BIT, dstStage);
 }
 
-void lvk::CommandBuffer::cmdCopyBuffer(BufferHandle srcBuffer, size_t srcBufferOffset, BufferHandle dstBuffer, size_t dstBufferOffset, size_t size) {
+void lvk::CommandBuffer::cmdCopyBuffer(BufferHandle srcBuffer, BufferHandle dstBuffer, size_t srcOffset, size_t dstOffset, size_t size) {
   LVK_PROFILER_FUNCTION();
   LVK_ASSERT(srcBuffer.valid());
   LVK_ASSERT(dstBuffer.valid());
   LVK_ASSERT(size);
   // Check buffer regions do not overlap
   if (srcBuffer == dstBuffer) {
-    if (srcBufferOffset < dstBufferOffset) {
-      LVK_ASSERT(dstBufferOffset - srcBufferOffset >= size);
+    if (srcOffset < dstOffset) {
+      LVK_ASSERT(dstOffset - srcOffset >= size);
     } else {
-      LVK_ASSERT(srcBufferOffset - dstBufferOffset >= size);
+      LVK_ASSERT(srcOffset - dstOffset >= size);
     }
   }
 
@@ -2611,8 +2611,8 @@ void lvk::CommandBuffer::cmdCopyBuffer(BufferHandle srcBuffer, size_t srcBufferO
 
   const VkBufferCopy2 copyRegion = {
       .sType = VK_STRUCTURE_TYPE_BUFFER_COPY_2,
-      .srcOffset = srcBufferOffset,
-      .dstOffset = dstBufferOffset,
+      .srcOffset = srcOffset,
+      .dstOffset = dstOffset,
       .size = size,
   };
 

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -373,7 +373,7 @@ class CommandBuffer final : public ICommandBuffer {
   void cmdPushConstants(const void* data, size_t size, size_t offset) override;
 
   void cmdFillBuffer(BufferHandle buffer, size_t bufferOffset, size_t size, uint32_t data) override;
-  void cmdCopyBuffer(BufferHandle srcBuffer, size_t srcBufferOffset, BufferHandle dstBuffer, size_t dstBufferOffset, size_t size);
+  void cmdCopyBuffer(BufferHandle srcBuffer, BufferHandle dstBuffer, size_t srcOffset, size_t dstOffset, size_t size);
   void cmdUpdateBuffer(BufferHandle buffer, size_t bufferOffset, size_t size, const void* data) override;
 
   void cmdDraw(uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t baseInstance) override;


### PR DESCRIPTION
Hello!

Couldn't see a way to do a direct buffer copy (say if I want to do something like create a larger version of an existing buffer and copy into it), so I've added a function for it. A little fuzzy on setting up the pipeline barriers to be correct within the framework, but hope this is right. Have tested a few basic configurations and seems to work as expected.