### PR TITLE
Recreate Swapchain overload with present mode option

### DIFF
--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -1179,8 +1179,7 @@ class IContext {
   virtual ColorSpace getSwapchainColorSpace() const = 0;
   virtual uint32_t getSwapchainCurrentImageIndex() const = 0;
   virtual uint32_t getNumSwapchainImages() const = 0;
-  virtual void recreateSwapchain(int newWidth, int newHeight) = 0;
-  virtual void recreateSwapchain(int newWidth, int newHeight, PresentMode newPresentMode) = 0;
+  virtual void recreateSwapchain(int newWidth, int newHeight, PresentMode) = 0;
 
   // MSAA level is supported if ((samples & bitmask) != 0), where samples must be power of two.
   virtual uint32_t getFramebufferMSAABitMask() const = 0;

--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -1179,7 +1179,8 @@ class IContext {
   virtual ColorSpace getSwapchainColorSpace() const = 0;
   virtual uint32_t getSwapchainCurrentImageIndex() const = 0;
   virtual uint32_t getNumSwapchainImages() const = 0;
-  virtual void recreateSwapchain(int newWidth, int newHeight, PresentMode) = 0;
+  virtual void recreateSwapchain(int newWidth, int newHeight) = 0;
+  virtual void setPresentMode(PresentMode newPresentMode) = 0;
 
   // MSAA level is supported if ((samples & bitmask) != 0), where samples must be power of two.
   virtual uint32_t getFramebufferMSAABitMask() const = 0;

--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -1180,6 +1180,7 @@ class IContext {
   virtual uint32_t getSwapchainCurrentImageIndex() const = 0;
   virtual uint32_t getNumSwapchainImages() const = 0;
   virtual void recreateSwapchain(int newWidth, int newHeight) = 0;
+  virtual void recreateSwapchain(int newWidth, int newHeight, PresentMode newPresentMode) = 0;
 
   // MSAA level is supported if ((samples & bitmask) != 0), where samples must be power of two.
   virtual uint32_t getFramebufferMSAABitMask() const = 0;

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -6207,6 +6207,11 @@ void lvk::VulkanContext::recreateSwapchain(int newWidth, int newHeight) {
   initSwapchain(newWidth, newHeight);
 }
 
+void lvk::VulkanContext::recreateSwapchain(int newWidth, int newHeight, PresentMode newPresentMode) {
+  config_.presentModes[0] = newPresentMode;
+  initSwapchain(newWidth, newHeight);
+}
+
 uint32_t lvk::VulkanContext::getFramebufferMSAABitMask() const {
   const VkPhysicalDeviceLimits& limits = getVkPhysicalDeviceProperties().limits;
   return limits.framebufferColorSampleCounts & limits.framebufferDepthSampleCounts;

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -6203,10 +6203,6 @@ uint32_t lvk::VulkanContext::getSwapchainCurrentImageIndex() const {
   return hasSwapchain() ? swapchain_->getSwapchainCurrentImageIndex() : 0;
 }
 
-void lvk::VulkanContext::recreateSwapchain(int newWidth, int newHeight) {
-  initSwapchain(newWidth, newHeight);
-}
-
 void lvk::VulkanContext::recreateSwapchain(int newWidth, int newHeight, PresentMode newPresentMode) {
   config_.presentModes[0] = newPresentMode;
   initSwapchain(newWidth, newHeight);

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -6203,9 +6203,12 @@ uint32_t lvk::VulkanContext::getSwapchainCurrentImageIndex() const {
   return hasSwapchain() ? swapchain_->getSwapchainCurrentImageIndex() : 0;
 }
 
-void lvk::VulkanContext::recreateSwapchain(int newWidth, int newHeight, PresentMode newPresentMode) {
-  config_.presentModes[0] = newPresentMode;
+void lvk::VulkanContext::recreateSwapchain(int newWidth, int newHeight) {
   initSwapchain(newWidth, newHeight);
+}
+
+void lvk::VulkanContext::setPresentMode(PresentMode newPresentMode) {
+  config_.presentModes[0] = newPresentMode;
 }
 
 uint32_t lvk::VulkanContext::getFramebufferMSAABitMask() const {

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -568,6 +568,7 @@ class VulkanContext final : public IContext {
   uint32_t getSwapchainCurrentImageIndex() const override;
   uint32_t getNumSwapchainImages() const override;
   void recreateSwapchain(int newWidth, int newHeight) override;
+  void recreateSwapchain(int newWidth, int newHeight, PresentMode newPresentMode) override;
 
   uint32_t getFramebufferMSAABitMask() const override;
   bool isExtensionEnabled(const char* ext) const override;

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -567,7 +567,8 @@ class VulkanContext final : public IContext {
   ColorSpace getSwapchainColorSpace() const override;
   uint32_t getSwapchainCurrentImageIndex() const override;
   uint32_t getNumSwapchainImages() const override;
-  void recreateSwapchain(int newWidth, int newHeight, PresentMode newPresentMode) override;
+  void recreateSwapchain(int newWidth, int newHeight) override;
+  void setPresentMode(PresentMode newPresentMode) override;
 
   uint32_t getFramebufferMSAABitMask() const override;
   bool isExtensionEnabled(const char* ext) const override;

--- a/lvk/vulkan/VulkanClasses.h
+++ b/lvk/vulkan/VulkanClasses.h
@@ -567,7 +567,6 @@ class VulkanContext final : public IContext {
   ColorSpace getSwapchainColorSpace() const override;
   uint32_t getSwapchainCurrentImageIndex() const override;
   uint32_t getNumSwapchainImages() const override;
-  void recreateSwapchain(int newWidth, int newHeight) override;
   void recreateSwapchain(int newWidth, int newHeight, PresentMode newPresentMode) override;
 
   uint32_t getFramebufferMSAABitMask() const override;


### PR DESCRIPTION
Added a new overload for `recreateSwapchain` function that allows user to pass in new present mode. Useful for changing present modes after initial creation of context with swapchain.