### PR TITLE
Added `ContextConfig::enableValidationGpuAV` to disable GPU-Assisted Validation

### DIFF
--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -1236,7 +1236,7 @@ struct ContextConfig {
   VulkanVersion vulkanVersion = VulkanVersion_1_3;
   bool terminateOnValidationError = false; // invoke std::terminate() on any validation error
   bool enableValidation = true;
-  bool enableValidationGpuAssisted = true;
+  bool enableValidationGpuAV = true;
   bool generateSPIRVDebugInfo = true;
   lvk::ColorSpace swapchainRequestedColorSpace = lvk::ColorSpace_SRGB_NONLINEAR;
   // owned by the application - should be alive until createVulkanContextWithSwapchain() returns

--- a/lvk/LVK.h
+++ b/lvk/LVK.h
@@ -1236,6 +1236,7 @@ struct ContextConfig {
   VulkanVersion vulkanVersion = VulkanVersion_1_3;
   bool terminateOnValidationError = false; // invoke std::terminate() on any validation error
   bool enableValidation = true;
+  bool enableValidationGpuAssisted = true;
   bool generateSPIRVDebugInfo = true;
   lvk::ColorSpace swapchainRequestedColorSpace = lvk::ColorSpace_SRGB_NONLINEAR;
   // owned by the application - should be alive until createVulkanContextWithSwapchain() returns

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -6908,9 +6908,6 @@ lvk::Result lvk::VulkanContext::createInstance() {
   const bool hasPortabilityEnumeration = hasExtension(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, allInstanceExtensions);
 
 #if defined(__APPLE__)
-  if (hasExtension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, allInstanceExtensions)) {
-    enabledInstanceExtensionNames_.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
-  }
   if (hasExtension(VK_MVK_MACOS_SURFACE_EXTENSION_NAME, allInstanceExtensions)) {
     has_MVK_macos_surface_ = true;
     enabledInstanceExtensionNames_.push_back(VK_MVK_MACOS_SURFACE_EXTENSION_NAME);
@@ -6928,6 +6925,10 @@ lvk::Result lvk::VulkanContext::createInstance() {
 
   if (hasDebugUtils) {
     enabledInstanceExtensionNames_.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+  }
+
+  if (hasExtension(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, allInstanceExtensions)) {
+    enabledInstanceExtensionNames_.push_back(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
   }
 
   if (config_.enableHeadlessSurface) {
@@ -6963,12 +6964,12 @@ lvk::Result lvk::VulkanContext::createInstance() {
   // GPU Assisted Validation doesn't work on Android.
   // It implicitly requires vertexPipelineStoresAndAtomics feature that's not supported even on high-end devices.
 #if defined(ANDROID)
-  const bool enableGpuAv = false;
+  const bool enableGpuAV = false;
 #else
-  const bool enableGpuAv = config_.enableValidation && config_.enableValidationGpuAssisted;
+  const bool enableGpuAV = config_.enableValidation && config_.enableValidationGpuAV;
 #endif // ANDROID
 
-  const VkBool32 gpuav_enable = enableGpuAv ? VK_TRUE : VK_FALSE;
+  const VkBool32 gpuav_enable = enableGpuAV ? VK_TRUE : VK_FALSE;
   const VkBool32 gpuav_post_process_descriptor_indexing = VK_FALSE; // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9222
 #define LAYER_SETTINGS_BOOL32(name, var)                                                                                        \
   VkLayerSettingEXT {                                                                                                           \
@@ -6982,7 +6983,6 @@ lvk::Result lvk::VulkanContext::createInstance() {
 #undef LAYER_SETTINGS_BOOL32
   const VkLayerSettingsCreateInfoEXT layerSettingsCreateInfo = {
       .sType = VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT,
-      .pNext = nullptr,
       .settingCount = (uint32_t)LVK_ARRAY_NUM_ELEMENTS(settings),
       .pSettings = settings,
   };
@@ -7013,11 +7013,7 @@ lvk::Result lvk::VulkanContext::createInstance() {
 
   const VkInstanceCreateInfo ci = {
       .sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
-#if defined(VK_EXT_layer_settings) && VK_EXT_layer_settings
       .pNext = &layerSettingsCreateInfo,
-#else
-      .pNext = nullptr,
-#endif // defined(VK_EXT_layer_settings) && VK_EXT_layer_settings
       .flags = hasPortabilityEnumeration ? VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR : 0u,
       .pApplicationInfo = &appInfo,
       .enabledLayerCount = config_.enableValidation ? (uint32_t)LVK_ARRAY_NUM_ELEMENTS(kDefaultValidationLayers) : 0u,

--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -6930,10 +6930,6 @@ lvk::Result lvk::VulkanContext::createInstance() {
     enabledInstanceExtensionNames_.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
   }
 
-  if (config_.enableValidation) {
-    enabledInstanceExtensionNames_.push_back(VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME); // enabled only for validation
-  }
-
   if (config_.enableHeadlessSurface) {
     enabledInstanceExtensionNames_.push_back(VK_EXT_HEADLESS_SURFACE_EXTENSION_NAME);
   }
@@ -6964,24 +6960,15 @@ lvk::Result lvk::VulkanContext::createInstance() {
     }
   }
 
-#if !defined(ANDROID)
   // GPU Assisted Validation doesn't work on Android.
   // It implicitly requires vertexPipelineStoresAndAtomics feature that's not supported even on high-end devices.
-  const VkValidationFeatureEnableEXT validationFeaturesEnabled[] = {
-      VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
-      VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT,
-  };
+#if defined(ANDROID)
+  const bool enableGpuAv = false;
+#else
+  const bool enableGpuAv = config_.enableValidation && config_.enableValidationGpuAssisted;
 #endif // ANDROID
 
-  const VkValidationFeaturesEXT features = {
-      .sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT,
-      .pNext = nullptr,
-#if !defined(ANDROID)
-      .enabledValidationFeatureCount = config_.enableValidation ? (uint32_t)LVK_ARRAY_NUM_ELEMENTS(validationFeaturesEnabled) : 0u,
-      .pEnabledValidationFeatures = config_.enableValidation ? validationFeaturesEnabled : nullptr,
-#endif
-  };
-
+  const VkBool32 gpuav_enable = enableGpuAv ? VK_TRUE : VK_FALSE;
   const VkBool32 gpuav_post_process_descriptor_indexing = VK_FALSE; // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9222
 #define LAYER_SETTINGS_BOOL32(name, var)                                                                                        \
   VkLayerSettingEXT {                                                                                                           \
@@ -6989,12 +6976,13 @@ lvk::Result lvk::VulkanContext::createInstance() {
     .pValues = var,                                                                                                             \
   }
   const VkLayerSettingEXT settings[] = {
+      LAYER_SETTINGS_BOOL32("gpuav_enable", &gpuav_enable),
       LAYER_SETTINGS_BOOL32("gpuav_post_process_descriptor_indexing", &gpuav_post_process_descriptor_indexing),
   };
 #undef LAYER_SETTINGS_BOOL32
   const VkLayerSettingsCreateInfoEXT layerSettingsCreateInfo = {
       .sType = VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT,
-      .pNext = config_.enableValidation ? &features : nullptr,
+      .pNext = nullptr,
       .settingCount = (uint32_t)LVK_ARRAY_NUM_ELEMENTS(settings),
       .pSettings = settings,
   };
@@ -7028,7 +7016,7 @@ lvk::Result lvk::VulkanContext::createInstance() {
 #if defined(VK_EXT_layer_settings) && VK_EXT_layer_settings
       .pNext = &layerSettingsCreateInfo,
 #else
-      .pNext = config_.enableValidation ? &features : nullptr,
+      .pNext = nullptr,
 #endif // defined(VK_EXT_layer_settings) && VK_EXT_layer_settings
       .flags = hasPortabilityEnumeration ? VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR : 0u,
       .pApplicationInfo = &appInfo,


### PR DESCRIPTION
GPU-AV instruments shaders with SPIR-V that some drivers (e.g. MoltenVK) cannot compile to native. The new flag (default true) lets applications keep core validation while dropping GPU-AV. Gated together with `enableValidation`.