### PR TITLE
Vulkan: enable `storagePushConstant16` if supported

### DIFF
--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -7432,6 +7432,7 @@ lvk::Result lvk::VulkanContext::initContext(const HWDeviceDesc& desc) {
       .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES,
       .pNext = config_.extensionsDeviceFeatures,
       .storageBuffer16BitAccess = VK_TRUE,
+      .storagePushConstant16 = vkFeatures11_.storagePushConstant16, // enable if supported
       .storageInputOutput16 = vkFeatures11_.storageInputOutput16, // enable if supported
       .multiview = vkFeatures11_.multiview, // enable if supported
       .variablePointersStorageBuffer = VK_TRUE,


### PR DESCRIPTION
Allows shaders to use 16-bit (half) data reached through buffer-device-address pointers held in push constants. Requested conditionally from the queried `VkPhysicalDeviceVulkan11Features` so it does not break device creation on drivers without it, matching the neighbouring optional 1.1 features.