### PR TITLE
Fix storage buffer usage flags

### DIFF
--- a/lvk/vulkan/VulkanClasses.cpp
+++ b/lvk/vulkan/VulkanClasses.cpp
@@ -4508,6 +4508,8 @@ lvk::Holder<lvk::BufferHandle> lvk::VulkanContext::createBuffer(const BufferDesc
 
   if (desc.usage & BufferUsageBits_Storage) {
     usageFlags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    usageFlags |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                  VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
   }
 
   if (desc.usage & BufferUsageBits_Indirect) {


### PR DESCRIPTION
VK_BUFFER_USAGE_TRANSFER_SRC_BIT is required if storage buffer is a source of copying